### PR TITLE
Fix VBA for .Net4

### DIFF
--- a/DotNetToJScript/Resources/vba_template.txt
+++ b/DotNetToJScript/Resources/vba_template.txt
@@ -19,7 +19,10 @@ Function Run()
     Dim stm As Object, fmt As Object, al As Object
     Set stm = CreateObject("System.IO.MemoryStream")
 
-    If stm Is Nothing Then
+    Dim dotnetversion As String
+    dotnetversion = "%DOTNETVERSION%"
+
+    If dotnetversion <> "v2" Then
         %MANIFEST%
 
         Set ax = CreateObject("Microsoft.Windows.ActCtx")

--- a/DotNetToJScript/VBAGenerator.cs
+++ b/DotNetToJScript/VBAGenerator.cs
@@ -89,6 +89,7 @@ namespace DotNetToJScript
         {
             string hex_encoded = BitConverter.ToString(serialized_object).Replace("-", "");
             StringBuilder builder = new StringBuilder();
+            string dotnetversion = (version != RuntimeVersion.v2) ? "v4" : "v2";
 
             for (int i = 0; i < hex_encoded.Length; i++)
             {
@@ -119,6 +120,9 @@ namespace DotNetToJScript
                                             ).Replace(
                                                 "%ADDEDSCRIPT%",
                                                 additional_script
+                                            ).Replace(
+                                                "%DOTNETVERSION%",
+                                                dotnetversion
                                             );
         }
     }


### PR DESCRIPTION
I cannot make the VBA works for .Net V4 project, even for the ExampleAssembly. After some verification, I found the variable "stm" is not empty for my environments.(Win 10 1903). In short, I just add a variable "dotnetversion" and check whether it is .Net v2 OR .Net V4. Feel free to discuss about it. Thanks.